### PR TITLE
Fix wrong app group ID for phone call UserDefaults

### DIFF
--- a/ios/TricordarrKit/Helpers/WebsocketNotifier.swift
+++ b/ios/TricordarrKit/Helpers/WebsocketNotifier.swift
@@ -310,15 +310,15 @@ public class WebsocketNotifier: NSObject {
 
 		case .phoneCallAnswered:
 			sendNotification = false
-			UserDefaults(suiteName: "group.com.challfry-FQD.Kraken")?
+			UserDefaults(suiteName: "group.com.grantcohoe.tricordarr")?
 				.set(socketNotification.contentID, forKey: "phoneCallAnswered")
-			self.logger.log("KrakenPushProvider set UserDefault for phoneCallAnswered")
+			self.logger.log("TricordarrPushProvider set UserDefault for phoneCallAnswered")
 
 		case .phoneCallEnded:
 			sendNotification = false
-			UserDefaults(suiteName: "group.com.challfry-FQD.Kraken")?
+			UserDefaults(suiteName: "group.com.grantcohoe.tricordarr")?
 				.set(socketNotification.contentID, forKey: "phoneCallEnded")
-			self.logger.log("KrakenPushProvider set UserDefault for phoneCallEnded")
+			self.logger.log("TricordarrPushProvider set UserDefault for phoneCallEnded")
 
 		case .followedEventStarting:
 			title = "Followed Event Starting"


### PR DESCRIPTION
## Summary

- `WebsocketNotifier.swift` used the old Kraken app group (`group.com.challfry-FQD.Kraken`) for `phoneCallAnswered` and `phoneCallEnded` UserDefaults writes. The actual app group in entitlements is `group.com.grantcohoe.tricordarr`.
- This means phone call state wasn't being shared between the `LocalPushExtension` and the main app — the extension writes to a suite the main app never reads.
- Two-line fix: updated the suite name to match entitlements. Also updated log messages from "KrakenPushProvider" to "TricordarrPushProvider".

No rush on this — totally fine to land after the cruise if the timing doesn't work for a pre-sailing release. 🚢

## Test plan

- [x] Builds and launches successfully on iPhone 16 simulator
- [ ] Verify phone call answered/ended state syncs between extension and main app (requires real device + running server)