### PR TITLE
fix: restrict Shutternaut management access

### DIFF
--- a/__tests__/unit/TestAppDrawer.tsx
+++ b/__tests__/unit/TestAppDrawer.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+
+import {AppDrawer} from '#src/Components/Drawers/AppDrawer';
+
+let mockHasTwitarrTeam = false;
+let mockHasShutternautManager = false;
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useEffect: jest.fn(),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({addListener: jest.fn()}),
+}));
+
+jest.mock('react-native', () => ({
+  Linking: {openURL: jest.fn()},
+  ScrollView: 'ScrollView',
+  StyleSheet: {create: (styles: object) => styles},
+}));
+
+jest.mock('react-native-device-info', () => ({getVersion: () => 'test'}));
+jest.mock('react-native-drawer-layout', () => ({Drawer: 'Drawer'}));
+jest.mock('react-native-paper', () => ({
+  Badge: 'Badge',
+  Drawer: {Item: 'DrawerItem', Section: 'DrawerSection'},
+}));
+
+jest.mock('#src/Context/Contexts/DrawerContext', () => ({
+  useDrawer: () => ({drawerOpen: false, setDrawerOpen: jest.fn()}),
+}));
+jest.mock('#src/Context/Contexts/OobeContext', () => ({useOobe: () => ({oobeCompleted: false})}));
+jest.mock('#src/Context/Contexts/PreRegistrationContext', () => ({
+  usePreRegistration: () => ({preRegistrationMode: false}),
+}));
+jest.mock('#src/Context/Contexts/PrivilegeContext', () => ({
+  usePrivilege: () => ({hasModerator: false, hasTwitarrTeam: mockHasTwitarrTeam, hasVerified: false}),
+}));
+jest.mock('#src/Context/Contexts/RoleContext', () => ({
+  useRoles: () => ({
+    hasShutternaut: false,
+    hasShutternautManager: mockHasShutternautManager,
+  }),
+}));
+jest.mock('#src/Context/Contexts/StyleContext', () => ({
+  useStyles: () => ({commonStyles: {background: {}, safePaddingVertical: {}}}),
+}));
+jest.mock('#src/Enums/Icons', () => ({AppIcons: {}}));
+jest.mock('#src/Queries/Alert/NotificationQueries', () => ({
+  useUserNotificationDataQuery: () => ({data: undefined}),
+}));
+jest.mock('#src/Queries/User/UserQueries', () => ({
+  useUserProfileQuery: () => ({data: undefined}),
+}));
+
+const getDrawerLabels = () => {
+  const drawer = AppDrawer({children: null});
+  const drawerContent = drawer.props.renderDrawerContent();
+  const labels: string[] = [];
+
+  const visit = (node: React.ReactNode) => {
+    React.Children.forEach(node, child => {
+      if (!React.isValidElement<{children?: React.ReactNode; label?: string}>(child)) {
+        return;
+      }
+      if (child.props.label) {
+        labels.push(child.props.label);
+      }
+      visit(child.props.children);
+    });
+  };
+
+  visit(drawerContent);
+  return labels;
+};
+
+describe('AppDrawer Shutternaut management access', () => {
+  beforeEach(() => {
+    mockHasTwitarrTeam = false;
+    mockHasShutternautManager = false;
+  });
+
+  it('does not offer Manage Shutternauts to TwitarrTeam alone', () => {
+    mockHasTwitarrTeam = true;
+
+    expect(getDrawerLabels()).not.toContain('Manage Shutternauts');
+  });
+
+  it('continues to offer Manage Shutternauts to Shutternaut Managers', () => {
+    mockHasShutternautManager = true;
+
+    expect(getDrawerLabels()).toContain('Manage Shutternauts');
+  });
+});

--- a/src/Components/Drawers/AppDrawer.tsx
+++ b/src/Components/Drawers/AppDrawer.tsx
@@ -190,7 +190,7 @@ export const AppDrawer = ({children}: PropsWithChildren) => {
                   onPress={() => Linking.openURL(`tricordarr://twitarrtab/${Date.now()}/dayplanner/shutternauts`)}
                 />
               )}
-              {(hasShutternautManager || hasTwitarrTeam) && (
+              {hasShutternautManager && (
                 <PaperDrawer.Item
                   label={'Manage Shutternauts'}
                   icon={AppIcons.shutternautManager}


### PR DESCRIPTION
## Summary

- hide **Manage Shutternauts** from users who only have TwitarrTeam privileges
- preserve the drawer action for users with the Shutternaut Manager role
- cover both sides of the permission boundary with focused tests

## Checks

- `npx --no-install jest __tests__/unit/TestAppDrawer.tsx --runInBand` — 2 passed; the same test against the base failed on the TwitarrTeam-only case as expected
- `npm run typecheck`
- `npx --no-install eslint src/Components/Drawers/AppDrawer.tsx __tests__/unit/TestAppDrawer.tsx`

The checks ran with Node 22 in a clean container with networking disabled during execution.

Fixes #487

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1029:start -->
### Verification

[Northset proof-of-pass receipt M-1029](https://northset-oss.github.io/verification-pilot/receipts/M-1029/)  
This record covers Northset’s own contribution; it is not maintainer verification.
Maintainers can request a separate, private run for a PR already in their queue at oss@northset.ai.
For repositories already onboarded with Northset, adding `northset-verify` to a PR requests a run on that PR.
<!-- northset-receipt:M-1029:end -->
